### PR TITLE
Alter allegro implementation to support pre-9.0 versions without :smputils

### DIFF
--- a/bordeaux-threads.asd
+++ b/bordeaux-threads.asd
@@ -7,7 +7,8 @@ Distributed under the MIT license (see LICENSE file)
 |#
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  #+allegro (require :smputil)
+  #+(and allegro (version>= 9)) (require :smputil)
+  #+(and allegro (not (version>= 9))) (require :process)
   #+corman  (require :threads))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)

--- a/src/impl-allegro.lisp
+++ b/src/impl-allegro.lisp
@@ -36,13 +36,22 @@ Distributed under the MIT license (see LICENSE file)
 ;;; Resource contention: condition variables
 
 (defun make-condition-variable (&key name)
-  (mp:make-condition-variable :name name))
+  #-(version>= 9)(declare (ignore name))
+  #-(version>= 9)(mp:make-gate nil)
+  #+(version>= 9)(mp:make-condition-variable :name name))
 
 (defun condition-wait (condition-variable lock)
-  (mp:condition-variable-wait condition-variable lock))
-
+  #-(version>= 9)
+  (progn
+    (release-lock lock)
+    (mp:process-wait "wait for message" #'mp:gate-open-p condition-variable)
+    (acquire-lock lock)
+    (mp:close-gate condition-variable))
+  #+(version>= 9)(mp:condition-variable-wait condition-variable lock))
+ 
 (defun condition-notify (condition-variable)
-  (mp:condition-variable-signal condition-variable))
+  #-(version>= 9)(mp:open-gate condition-variable)
+  #+(version>= 9)(mp:condition-variable-signal condition-variable))
 
 (defun thread-yield ()
   (mp:process-allow-schedule))


### PR DESCRIPTION
I have a need for bordeaux-threads to work on Allegro Common Lisp < 9.0. 8.1 to be precise.

The current Bordeaux Threads is updated to require the 9.0+ `:smputil` package instead of the older `:process` package.

I found up the patch which upgrades the implementation, and added back the old implementation, conditional on the allegro version>= feature.

The upshot is that ACL 9.0+ versions should work as before (not tested, but trivial by analysis), and bordeaux-threads now works on versions pre-8.0 again.
