### PR TITLE
SBCL: reacquire lock in CONDITION-WAIT on timeout

### DIFF
--- a/src/impl-sbcl.lisp
+++ b/src/impl-sbcl.lisp
@@ -63,7 +63,11 @@ Distributed under the MIT license (see LICENSE file)
   (sb-thread:make-waitqueue :name (or name "Anonymous condition variable")))
 
 (defun condition-wait (condition-variable lock &key timeout)
-  (sb-thread:condition-wait condition-variable lock :timeout timeout))
+  (let ((result (sb-thread:condition-wait condition-variable lock
+                                          :timeout timeout)))
+    (unless result
+      (acquire-lock lock))
+    result))
 
 (defun condition-notify (condition-variable)
   (sb-thread:condition-notify condition-variable))


### PR DESCRIPTION
For a `condition-wait` timeout expiring, SBCL appears to be the only implementation that returns without the lock being held. Reacquiring the lock inside `condition-wait` is the most obvious solution. The alternative would be to tell users that the lock state is unknown and provide `lock-acquired-p`. It would seem unintuitive that a lock is not necessarily held inside `with-lock-held`.

I can see a reason for SBCL doing this -- if the timeout expires then one is likely to give up whatever activity was needed for the lock. However if that activity is, say, consuming data, then it can't hurt trying to consume one last time, so reacquiring the lock need not be a total waste.
