### PR TITLE
abcl: explicitly use JVM API for thread yield

### DIFF
--- a/src/impl-abcl.lisp
+++ b/src/impl-abcl.lisp
@@ -93,7 +93,7 @@ Distributed under the MIT license (see LICENSE file)
 ;;; Resource contention: condition variables
 
 (defun thread-yield ()
-  (sleep 0))
+  (java:jstatic "yield" "java.lang.Thread"))
 
 (defstruct condition-variable
   (name "Anonymous condition variable"))


### PR DESCRIPTION
I'm guessing that this should fix your problems with your Travis CI hanging, but I have been unable to replicate.

If this commit doesn't fix things, please let me know the values for LISP-IMPLEMENTATION-VERSION on the Travis CI host to try to establish a similar environment.