### PR TITLE
Fix CMUCL recursive locks

### DIFF
--- a/src/impl-cmucl.lisp
+++ b/src/impl-cmucl.lisp
@@ -53,6 +53,15 @@ Distributed under the MIT license (see LICENSE file)
 
 (defmacro with-lock-held ((place) &body body)
   `(mp:with-lock-held (,place) ,@body))
+  
+(defun make-recursive-lock (&optional name)
+  (make-lock name))
+
+(defun acquire-recursive-lock (lock)
+  (acquire-lock lock))
+
+(defun release-recursive-lock (lock)
+  (release-lock lock))
 
 (defmacro with-recursive-lock-held ((place &key timeout) &body body)
   `(mp:with-lock-held (,place "Lock Wait" :timeout ,timeout) ,@body))


### PR DESCRIPTION
When we do `(drakma:http-request "https://google.com/")` on CMUCL, drakma fails with error
```
Unexpected Error: #<TYPE-ERROR {590EC76D}>
Type-error in KERNEL::OBJECT-NOT-INSTANCE-ERROR-HANDLER:
   (NIL) is not of type EXTENSIONS:INSTANCE..
```

(example log of drakma tests http://cl-test-grid.appspot.com/blob?key=1xh2x7qdy2)

This happens because cl+ssl calls `bordeaux-threads:make-recursive-lock` which returns `(list nil)` on CMUCL.
This patch provides real implementation for recursive locks BT functions. With this drakma successfully fetches HTTPS URLs.