### PR TITLE
Add WRAPPERS keyword parameter to MAKE-THREAD

### DIFF
--- a/src/default-implementations.lisp
+++ b/src/default-implementations.lisp
@@ -27,7 +27,8 @@ It is safe to call repeatedly."
   nil)
 
 (defdfun make-thread (function &key name
-                      (initial-bindings *default-special-bindings*))
+                      (initial-bindings *default-special-bindings*)
+                      (wrappers         *default-wrappers*))
   "Creates and returns a thread named NAME, which will call the
   function FUNCTION with no arguments: when FUNCTION returns, the
   thread terminates. NAME defaults to \"Anonymous thread\" if unsupplied.
@@ -53,9 +54,41 @@ It is safe to call repeatedly."
     shared with the new thread that it creates: this is
     implementation-defined. Portable code should not depend on
     particular behaviour in this case, nor should it assign to such
-    variables without first rebinding them in the new thread."
-  (%make-thread (binding-default-specials function initial-bindings)
-                (or name "Anonymous thread")))
+    variables without first rebinding them in the new thread.
+
+  WRAPPERS is a list of functions, defaulting to *DEFAULT-WRAPPERS* if
+  not supplied, to transform FUNCTION. The last function is called
+  with FUNCTION as its argument and must return a new thread function,
+  usually wrapping the original one. The result is passed to the
+  remaining functions (in reverse order) until the first function
+  returns a function that becomes the effective thread function.
+
+  Example:
+
+    (let ((bordeaux-threads:*default-wrappers*
+           (list (lambda (next)
+                   ;;            v parent thread
+                   (let ((thread (bt:current-thread)))
+                     (lambda ()
+                       (list 1 thread (funcall next)))))
+                 (lambda (next)
+                   (lambda ()
+                     ;;      v child thread
+                     (list 2 (bt:current-thread) (funcall next)))))))
+      (bt:join-thread (bt:make-thread (lambda () :function))))
+    => (1 <parent thread> (2 <child thread> :function))
+
+  where <parent thread> is the thread calling BT:MAKE-THREAD and
+  <child thread> is the thread created by the BT:MAKE-THREAD call."
+  (let ((effective-wrappers
+         (if initial-bindings
+             (list* (binding-default-specials initial-bindings)
+                    wrappers)
+             wrappers)))
+    (%make-thread (if effective-wrappers
+                      (apply-wrappers function effective-wrappers)
+                      function)
+                  (or name "Anonymous thread"))))
 
 (defdfun %make-thread (function name)
   "The actual implementation-dependent function that creates threads."

--- a/src/pkgdcl.lisp
+++ b/src/pkgdcl.lisp
@@ -7,6 +7,7 @@
   (:import-from :java #:jnew #:jcall #:jmethod)
   (:export #:thread #:make-thread #:current-thread #:threadp #:thread-name
            #:start-multiprocessing
+           #:*default-wrappers*
            #:*default-special-bindings* #:*standard-io-bindings*
            #:*supports-threads-p*
 

--- a/test/bordeaux-threads-test.lisp
+++ b/test/bordeaux-threads-test.lisp
@@ -11,7 +11,7 @@ Distributed under the MIT license (see LICENSE file)
 (in-package #:bordeaux-threads/test)
 
 (def-suite :bordeaux-threads)
-(def-fixture using-lock () 
+(def-fixture using-lock ()
   (let ((lock (make-lock)))
     (&body)))
 (in-suite :bordeaux-threads)
@@ -60,6 +60,20 @@ Distributed under the MIT license (see LICENSE file)
 (defun set-equal (set-a set-b)
   (and (null (set-difference set-a set-b))
        (null (set-difference set-b set-a))))
+
+(test wrappers
+  (let* ((bordeaux-threads:*default-wrappers*
+          (list* (lambda (next)
+                   (let ((thread (bt:current-thread)))
+                     (lambda ()
+                       (list 1 thread (funcall next)))))
+                 (lambda (next)
+                   (lambda ()
+                     (list 2 (bt:current-thread) (funcall next))))
+                 bordeaux-threads:*default-wrappers*))
+         (thread (bt:make-thread (lambda () :function))))
+    (is (equal `(1 ,(bt:current-thread) (2 ,thread :function))
+               (bt:join-thread thread)))))
 
 (test default-special-bindings
   (locally (declare (special *a* *c*))


### PR DESCRIPTION
This is a draft implementation of a feature I was missing on several occasions and would like to discuss. If there is interest, I can improve and document the code.
- Wrappers are somewhat similar to initial bindings but more general: they can be used to bind variables (with clearer semantics than `initial-bindings`), establish handlers, restarts or catch tags or perform side effects (again with clearer semantics than `initial-bindings`)
- The new variable `*default-bindings*` serves as the default value if the parameter is not supplied

I consider this a more powerful and (imo) easier to understand mechanism than initial bindings. The use cases leading me to this idea were:
- Thread support in fiveam: the `is` macro currently only works in the thread executing the `test`. Using the wrappers mechanism, `test` can arrange for threads created within the scope of the test to forward conditions signaled by `is` (or otherwise) to the current test. For a crude, prototypical implementation, see the [fiveam pull request](https://github.com/sionescu/fiveam/pull/27).
- Consider a [generic progress condition](https://github.com/scymtym/more-conditions#tracking-and-reporting-progress-of-operations) (neither a warning nor an error or a serious condition) that can be freely signaled from any operation to convey its progress without disturbing surrounding control flow. It would be nice to collect all conditions of this kind no matter from which thread they were signaled or who created the thread. This could be achieved by globally pushing a suitable wrapper onto `*default-wrappers*`.
