### PR TITLE
Add LOCKP predicate and LOCK type

### DIFF
--- a/src/default-implementations.lisp
+++ b/src/default-implementations.lisp
@@ -80,6 +80,16 @@ It is safe to call repeatedly."
 
 ;;; Resource contention: locks and recursive locks
 
+(defdfun lock-p (object)
+  "Returns T if OBJECT is a lock; returns NIL otherwise."
+  (declare (ignore object))
+  (values))
+
+(defdfun recursive-lock-p (object)
+  "Returns T if OBJECT is a recursive lock; returns NIL otherwise."
+  (declare (ignore object))
+  (values))
+
 (defdfun make-lock (&optional name)
   "Creates a lock (a mutex) whose name is NAME. If the system does not
   support multiple threads this will still return some object, but it
@@ -91,7 +101,7 @@ It is safe to call repeatedly."
   (list nil))
 
 (defdfun acquire-lock (lock &optional wait-p)
-  "Acquire the lock LOCK for the calling thread.
+    "Acquire the lock LOCK for the calling thread.
   WAIT-P governs what happens if the lock is not available: if WAIT-P
   is true, the calling thread will wait until the lock is available
   and then acquire it; if WAIT-P is NIL, ACQUIRE-LOCK will return

--- a/src/impl-abcl.lisp
+++ b/src/impl-abcl.lisp
@@ -48,6 +48,16 @@ Distributed under the MIT license (see LICENSE file)
 (defconstant +get-hold-count+ 
   (jmethod "java.util.concurrent.locks.ReentrantLock" "getHoldCount"))
 
+(deftype lock () 'mutex)
+
+(deftype recursive-lock () 'mutex-recursive)
+
+(defun lock-p (object)
+  (typep object 'mutex))
+
+(defun recursive-lock-p (object)
+  (typep object 'mutex-recursive))
+
 (defun make-lock (&optional name)
   (make-mutex 
    :name (or name "Anonymous lock")

--- a/src/impl-allegro.lisp
+++ b/src/impl-allegro.lisp
@@ -13,6 +13,16 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+(deftype lock () 'mp:process-lock)
+
+(deftype recursive-lock () 'mp:process-lock)
+
+(defun lock-p (object)
+  (typep object 'mp:process-lock))
+
+(defun recursive-lock-p (object)
+  (typep object 'mp:process-lock))
+
 (defun make-lock (&optional name)
   (mp:make-process-lock :name (or name "Anonymous lock")))
 

--- a/src/impl-clisp.lisp
+++ b/src/impl-clisp.lisp
@@ -28,6 +28,18 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+(deftype lock () 'mt:mt-mutex)
+
+(deftype recursive-lock ()
+  '(and mt:mt-mutex (satisfies mt:mutex-recursive-p)))
+
+(defun lock-p (object)
+  (typep object 'mt:mt-mutex))
+
+(defun recursive-lock-p (object)
+  (and (typep object 'mt:mt-mutex)
+       (mt:mutex-recursive-p object)))
+
 (defun make-lock (&optional name)
   (mt:make-mutex :name (or name "Anonymous lock")))
 

--- a/src/impl-clozure.lisp
+++ b/src/impl-clozure.lisp
@@ -30,6 +30,16 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+(deftype lock () 'ccl:lock)
+
+(deftype recursive-lock () 'ccl:lock)
+
+(defun lock-p (object)
+  (typep object 'ccl:lock))
+
+(defun recursive-lock-p (object)
+  (typep object 'ccl:lock))
+
 (defun make-lock (&optional name)
   (ccl:make-lock (or name "Anonymous lock")))
 

--- a/src/impl-cmucl.lisp
+++ b/src/impl-cmucl.lisp
@@ -40,6 +40,16 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+(deftype lock () 'mp:error-check-lock)
+
+(deftype recursive-lock () 'mp:recursive-lock)
+
+(defun lock-p (object)
+  (typep object 'mp:error-check-lock))
+
+(defun recursive-lock-p (object)
+  (typep object 'mp:recursive-lock))
+
 (defun make-lock (&optional name)
   (mp:make-lock (or name "Anonymous lock")))
 

--- a/src/impl-ecl.lisp
+++ b/src/impl-ecl.lisp
@@ -30,6 +30,18 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+(deftype lock () 'mp:lock)
+
+(deftype recursive-lock ()
+  '(and mp:lock (satisfies mp:recursive-lock-p)))
+
+(defun lock-p (object)
+  (typep object 'mp:lock))
+
+(defun recursive-lock-p (object)
+  (and (typep object 'mp:lock)
+       (mp:recursive-lock-p object)))
+
 (defun make-lock (&optional name)
   (mp:make-lock :name (or name "Anonymous lock")))
 

--- a/src/impl-lispworks.lisp
+++ b/src/impl-lispworks.lisp
@@ -44,6 +44,19 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+
+(deftype lock () 'mp:lock)
+
+(deftype recursive-lock ()
+  '(and mp:lock (satisfies mp:lock-recursive-p)))
+
+(defun lock-p (object)
+  (typep object 'mp:lock))
+
+(defun recursive-lock-p (object)
+  (and (typep object 'mp:lock)
+       (mp:lock-recursive-p object)))
+
 (defun make-lock (&optional name)
   (mp:make-lock :name (or name "Anonymous lock")
                 #-(or lispworks4 lispworks5) :recursivep

--- a/src/impl-mcl.lisp
+++ b/src/impl-mcl.lisp
@@ -27,6 +27,11 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+(deftype lock () 'ccl:lock)
+
+(defun lock-p (object)
+  (typep object 'ccl:lock))
+
 (defun make-lock (&optional name)
   (ccl:make-lock (or name "Anonymous lock")))
 

--- a/src/impl-mkcl.lisp
+++ b/src/impl-mkcl.lisp
@@ -28,6 +28,18 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+(deftype lock () 'mt:lock)
+
+(deftype recursive-lock ()
+  '(and mt:lock (satisfies mt:recursive-lock-p)))
+
+(defun lock-p (object)
+  (typep object 'mt:lock))
+
+(defun recursive-lock-p (object)
+  (and (typep object 'mt:lock)
+       (mt:recursive-lock-p object)))
+
 (defun make-lock (&optional name)
   (mt:make-lock :name (or name "Anonymous lock")))
 

--- a/src/impl-sbcl.lisp
+++ b/src/impl-sbcl.lisp
@@ -30,6 +30,16 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+(deftype lock () 'sb-thread:mutex)
+
+(deftype recursive-lock () 'sb-thread:mutex)
+
+(defun lock-p (object)
+  (typep object 'sb-thread:mutex))
+
+(defun recursive-lock-p (object)
+  (typep object 'sb-thread:mutex))
+
 (defun make-lock (&optional name)
   (sb-thread:make-mutex :name (or name "Anonymous lock")))
 

--- a/src/impl-scl.lisp
+++ b/src/impl-scl.lisp
@@ -25,6 +25,16 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
+(deftype lock () 'thread:lock)
+
+(deftype recursive-lock () 'thread:recursive-lock)
+
+(defun lock-p (object)
+  (typep object 'thread:lock))
+
+(defun recursive-lock-p (object)
+  (typep object 'thread:recursive-lock))
+
 (defun make-lock (&optional name)
   (thread:make-lock (or name "Anonymous lock")))
 

--- a/src/pkgdcl.lisp
+++ b/src/pkgdcl.lisp
@@ -10,9 +10,9 @@
            #:*default-special-bindings* #:*standard-io-bindings*
            #:*supports-threads-p*
 
-           #:make-lock #:acquire-lock #:release-lock #:with-lock-held
-           #:make-recursive-lock #:acquire-recursive-lock
-           #:release-recursive-lock #:with-recursive-lock-held
+           #:make-lock #:lock-p #:recursive-lock-p #:acquire-lock #:release-lock
+           #:with-lock-held #:make-recursive-lock #:acquire-recursive-lock
+           #:release-recursive-lock #:with-recursive-lock-held #:lock #:recursive-lock
 
            #:make-condition-variable #:condition-wait #:condition-notify
 


### PR DESCRIPTION
I just added a bit of functionality that I found missing from bordeaux-threads - a LOCKP predicate that answers whether something is a lock and LOCK type that works by satisfying LOCKP.

What do you think about it?