### PR TITLE
ensure version.sexp is bundled by asdf

### DIFF
--- a/bordeaux-threads.asd
+++ b/bordeaux-threads.asd
@@ -33,7 +33,8 @@ Distributed under the MIT license (see LICENSE file)
                #+(and allegro (version>= 9))       (:require "smputil")
                #+(and allegro (not (version>= 9))) (:require "process")
                #+corman                            (:require "threads"))
-  :components ((:module "src"
+  :components ((:static-file "version.sexp")
+               (:module "src"
                 :serial t
                 :components
                 ((:file "pkgdcl")


### PR DESCRIPTION
I had Armed Bear Common Lisp create a jar file of my application. The jar file included bordeaux-threads. However, bordeaux-threads could not be loaded from its lisp source files in the jar because they (bordeaux-threads.asd) required the version data file, which hadn't been bundled. This fixes that.