### PR TITLE
impl-ecl: condition-wait: add timeout implementation

### DIFF
--- a/src/impl-ecl.lisp
+++ b/src/impl-ecl.lisp
@@ -74,9 +74,12 @@ Distributed under the MIT license (see LICENSE file)
 
 (defun condition-wait (condition-variable lock &key timeout)
   (if timeout
-      (mp:condition-variable-timedwait condition-variable lock timeout)
-      (mp:condition-variable-wait condition-variable lock))
-  t)
+      #.(if (<= ext:+ecl-version-number+ 160103)
+            `(handler-case (with-timeout (timeout)
+                             (mp:condition-variable-wait condition-variable lock))
+               (bt:timeout () nil))
+            `(mp:condition-variable-timedwait condition-variable lock timeout))
+      (mp:condition-variable-wait condition-variable lock)))
 
 (defun condition-notify (condition-variable)
   (mp:condition-variable-signal condition-variable))


### PR DESCRIPTION
Versions starting from 16.2.0 will have this implemented properly, but until now
condition-variable-timedwait signalled simple-error with "not implemented"
message.

We wrap condition-wait in with-timeout for ECL <= 16.1.3 if timeout is not NIL.