### PR TITLE
with-recursive-lock-held: default implementation was not congruent

### DIFF
--- a/src/default-implementations.lisp
+++ b/src/default-implementations.lisp
@@ -162,11 +162,10 @@ It is safe to call repeatedly."
   (declare (ignore lock))
   (values))
 
-(defdmacro with-recursive-lock-held ((place &key timeout) &body body)
+(defdmacro with-recursive-lock-held ((place) &body body)
   "Evaluates BODY with the recursive lock named by PLACE, which is a
 reference to a recursive lock created by MAKE-RECURSIVE-LOCK. See
 WITH-LOCK-HELD etc etc"
-  (declare (ignore timeout))
   `(when (acquire-recursive-lock ,place)
      (unwind-protect
           (locally ,@body)


### PR DESCRIPTION
All implementations in the source code doesn't provide lambda list for
with-recursive-lock-held with keyword argument timeout. I assume this is a typo,
because argument is not mentioned in docstring nor with-lock-held resembles this
choice. Closes #25.