### PR TITLE
Fixed loading in LispWorks 5

### DIFF
--- a/src/impl-lispworks-condition-variables.lisp
+++ b/src/impl-lispworks-condition-variables.lisp
@@ -1,5 +1,7 @@
 ;;;; -*- indent-tabs-mode: nil -*-
 
+(in-package #:bordeaux-threads)
+
 ;; Lispworks condition support is simulated, albeit via a lightweight wrapper over
 ;; its own polling-based wait primitive.  Waiters register with the condition variable,
 ;; and use MP:process-wait which queries for permission to proceed at its own (usspecified) interval.

--- a/src/impl-lispworks.lisp
+++ b/src/impl-lispworks.lisp
@@ -47,6 +47,7 @@ Distributed under the MIT license (see LICENSE file)
 
 (deftype lock () 'mp:lock)
 
+#-(or lispworks4 lispworks5)
 (deftype recursive-lock ()
   '(and mp:lock (satisfies mp:lock-recursive-p)))
 
@@ -54,6 +55,9 @@ Distributed under the MIT license (see LICENSE file)
   (typep object 'mp:lock))
 
 (defun recursive-lock-p (object)
+  #+(or lispworks4 lispworks5)
+  nil
+  #-(or lispworks4 lispworks5) ; version 6+
   (and (typep object 'mp:lock)
        (mp:lock-recursive-p object)))
 


### PR DESCRIPTION
Hi,

Bordeaux-threads has some minimal supports of LispWorks 5 (or even 4), but actually the whole package fails loading in LispWorks 5 (tested in LW 5.1.2 on Mac OS X 10.6).

This PR fixed the remain issues and now LW 5 loads bordeaux-threads successfully.   Two issues are:

1. The exported symbol `mp:lock-recursive-p` doesn't exist in LW 5.
2. The file `impl-lispworks-condition-variables.lisp` doesn't have an `(in-package ..)`.

I found this issue when loading CL-FAD which seems depending on bordeaux-threads.