### PR TITLE
Fixed loading in CMUCL 21b

### DIFF
--- a/src/impl-cmucl.lisp
+++ b/src/impl-cmucl.lisp
@@ -40,15 +40,15 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
-(deftype lock () 'mp:error-check-lock)
+(deftype lock () 'mp::error-check-lock)
 
-(deftype recursive-lock () 'mp:recursive-lock)
+(deftype recursive-lock () 'mp::recursive-lock)
 
 (defun lock-p (object)
-  (typep object 'mp:error-check-lock))
+  (typep object 'mp::error-check-lock))
 
 (defun recursive-lock-p (object)
-  (typep object 'mp:recursive-lock))
+  (typep object 'mp::recursive-lock))
 
 (defun make-lock (&optional name)
   (mp:make-lock (or name "Anonymous lock")


### PR DESCRIPTION
Hi,

I'm using CMU CL 20b on Mac OS X, and latest bordeaux-threads doesn't build correctly, because two lock-related classes are not exported in CMUCL's MP package but they're used as external ones `mp:...`.

This trivial PR fixes the problem.

--Chun