### PR TITLE
ensure that on all conforming common lisps, in particular ecl-13.5.1,…

### DIFF
--- a/src/default-implementations.lisp
+++ b/src/default-implementations.lisp
@@ -285,8 +285,8 @@ WITH-LOCK-HELD etc etc"
 (defdfun signal-semaphore (semaphore &key (count 1))
     "Increment SEMAPHORE by COUNT. If there are threads waiting on this
 semaphore, then COUNT of them are woken up."
+  (declare (notinline condition-notify))
   (with-lock-held ((%semaphore-lock semaphore))
-    (declare (notinline condition-notify))
     (incf (%semaphore-counter semaphore) count)
     (dotimes (v count)
       (condition-notify (%semaphore-condition-variable semaphore))))
@@ -300,8 +300,8 @@ T on success.
 
 If TIMEOUT is given, it is the maximum number of seconds to wait. If the count
 cannot be decremented in that time, returns NIL without decrementing the count."
+  (declare (notinline condition-wait))
   (with-lock-held ((%semaphore-lock semaphore))
-    (declare (notinline condition-wait))
     (if (>= (%semaphore-counter semaphore) 1)
         (decf (%semaphore-counter semaphore))
         (let ((deadline (when timeout


### PR DESCRIPTION
… default function implementations do not inline other default functions and ignore the implementation specific equivalents.

All of the following is merely my best hypothesis.

----
Conforming Common Lisp compilers are allowed to inline a call to a function that has a definition in the same file as the call.

On such compilers, #'make-thread defined in default-implementations.lisp might call the %make-thread function also defined in that file (which is written to raise an error at runtime), instead of the %make-thread defined in the impl-* file.

Most compilers appear to ignore the %make-thread defined in default-implementations.lisp because they notice the "(unless (fboundp ...))" guard clause, but they aren't required to by the Common Lisp spec.

Ref:
https://www.cs.cmu.edu/Groups/AI/html/cltl/clm/node227.html
Common Lisp the Language, 2nd Edition
25.1.3. Compilation Environment
"
In the absence of notinline declarations to the contrary, compile-file may assume that a call within the file being compiled to a named function that is defined in that file refers to that function. (This rule permits block compilation of files.) The behavior of the program is unspecified if functions are redefined individually at run time.
"

This patch fixes the problem in bordeaux-threads by declaring the call to %make-thread "notinline". More generally, it declares notinline all calls to functions designed to be overridden in impl-*.lisp but that also have a definition in default-implementations.lisp .

ECL-13.5.1 is a compiler on which the problem with bordeaux-threads can be demonstrated.
ECL-15.3.7 is not.
There may not be any other existing compilers on which the problem can be demonstrated. But that's besides the point. bordeaux-threads should be fixed, regardless. In particular, default-implementations.lisp should be fixed because it is meant to be the implementation-agnostic part of bordeaux-threads.

----
Here is how to reproduce the problem using quicklisp.

- place bordeaux-threads into ~/quicklisp/local-projects/
- rm -r ~/.cache/common-lisp/ecl*

Then do the following twice. (The second time, don't clear the cache above).
```
/usr/bin/ecl #ecl-13.5.1 installed by apt on Debian Linux 8
(load "asdf") ;the newest asdf.lisp (3.3.2)
(load "quicklisp/setup")
(ql:quickload "bordeaux-threads")
(bt:make-thread #'(lambda () 3))
(quit)
```
You'll find that the second time produces this error for (bt:make-thread ...):
```
Condition of type: BORDEAUX-MP-CONDITION
There is no support for this method on this implementation.
```
which comes from the %make-thread in default-implementations.lisp .

----
(For some reason, when you place bordeaux-threads into ~/ and asdf-load it from there instead, the problem doesn't appear. Maybe quicklisp compiles and loads files in a different way then.)

----
There's a simpler demonstration of the idea, using ECL-13.5.1 again. This doesn't need asdf, quicklisp or bordeaux-threads. Just ECL-13.5.1.

file1.lisp
```
(defun f ()
  (format t "in f~%"))
```
file2.lisp
```
(defun g ()
  (f))
(eval-when (:compile-toplevel :load-toplevel :execute)
  (unless (fboundp 'f)
    (defun f ()
      (format t "in default f~%"))))
```
Do:
```
(mapcar #'(lambda (f) (load (compile-file f)))
        '("file1" "file2"))
(g)
```
Observe the incorrect output:
```
  in default f
```
instead of the expected:
```
  in f
```
(The problem doesn't occur if you don't compile the files.)

If you make this the first line of g:
```
  (declare (notinline f))
```
that fixes the problem.