### PR TITLE
acquire/release for recursive locks in clisp

### DIFF
--- a/src/impl-clisp.lisp
+++ b/src/impl-clisp.lisp
@@ -56,6 +56,12 @@ Distributed under the MIT license (see LICENSE file)
   (mt:make-mutex :name (or name "Anonymous recursive lock")
                  :recursive-p t))
 
+(defun acquire-recursive-lock (lock &optional (wait-p t))
+  (acquire-lock lock wait-p))
+
+(defun release-recursive-lock (lock)
+  (release-lock lock))
+
 (defmacro with-recursive-lock-held ((place) &body body)
   `(mt:with-mutex-lock (,place) ,@body))
 


### PR DESCRIPTION
Calling the function below should have produced:
```
  in thread
  leaving
  in thread
  leaving
```
but it would produce:
```
  in thread
  in thread
  leaving
  leaving
```
This fixes that.
```
(defvar *test-lck* (make-recursive-lock "test-lock"))
(defun test2 ()
  (dotimes (i 2)
    (make-thread #'(lambda ()
                     (when (acquire-recursive-lock *test-lck*)
                       (unwind-protect
                         (progn
                           (format t "in thread~%")
                           (sleep 1)
                           (format t "leaving~%"))
                         (release-recursive-lock *test-lck*)))))))
```