### PR TITLE
Fix mutex type for recent CLISP

### DIFF
--- a/src/impl-clisp.lisp
+++ b/src/impl-clisp.lisp
@@ -28,16 +28,16 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Resource contention: locks and recursive locks
 
-(deftype lock () 'mt:mt-mutex)
+(deftype lock () 'mt:mutex)
 
 (deftype recursive-lock ()
-  '(and mt:mt-mutex (satisfies mt:mutex-recursive-p)))
+  '(and mt:mutex (satisfies mt:mutex-recursive-p)))
 
 (defun lock-p (object)
-  (typep object 'mt:mt-mutex))
+  (typep object 'mt:mutex))
 
 (defun recursive-lock-p (object)
-  (and (typep object 'mt:mt-mutex)
+  (and (typep object 'mt:mutex)
        (mt:mutex-recursive-p object)))
 
 (defun make-lock (&optional name)


### PR DESCRIPTION
Patch for issue #50.
In CLISP 2.49.92, the mutex type is ```mt:mutex```, not ```mt:mt-mutex```.
