### PR TITLE
Ensure TIMEOUT and WITH-TIMEOUT are defined on SBCL

### DIFF
--- a/src/bordeaux-threads.lisp
+++ b/src/bordeaux-threads.lisp
@@ -34,6 +34,18 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Timeouts
 
+;;; SBCL timeouts apparently do not require threading support. Provide definitions here, rather than
+;;; in impl-sbcl.lisp to ensure that TIMEOUT and WITH-TIMEOUT are defined, even if threading support
+;;; is not present.
+#+sbcl
+(deftype timeout ()
+  'sb-ext:timeout)
+
+#+sbcl
+(defmacro with-timeout ((timeout) &body body)
+  `(sb-ext:with-timeout ,timeout
+     ,@body))
+
 #-sbcl
 (define-condition timeout (serious-condition)
   ((length :initform nil

--- a/src/impl-sbcl.lisp
+++ b/src/impl-sbcl.lisp
@@ -83,12 +83,8 @@ Distributed under the MIT license (see LICENSE file)
 
 ;;; Timeouts
 
-(deftype timeout ()
-  'sb-ext:timeout)
-
-(defmacro with-timeout ((timeout) &body body)
-  `(sb-ext:with-timeout ,timeout
-     ,@body))
+;;; SBCL timeouts do not depend on SB-THREAD support, and hence are implemented alongside the
+;;; generic default versions in bordeaux-threads.lisp
 
 ;;; Semaphores
 


### PR DESCRIPTION
The default / fallback implementations of TIMEOUT and WITH-TIMEOUT in bordeaux-threads.lisp are guarded by an #-sbcl feature expression, and hence are not defined when compiling on SBCL without threading support.

SB-EXT:WITH-TIMEOUT appears to work even when compiled without threading support, so move the SBCL-specific definitions of TIMEOUT and WITH-TIMEOUT into bordeaux-threads.lisp to ensure they are always defined on SBCL.

Tested on SBCL 2.0.0 x86-64 macOS with and without threading support. With threading support, all tests pass. Without threading support, most tests understandably fail, but after this change the three WITH-TIMEOUT-* tests now pass.

Closes #61 