### PR TITLE
Fix recursive-lock-p, mp:lock no longer exported and wrong test anyhow

### DIFF
--- a/src/impl-clasp.lisp
+++ b/src/impl-clasp.lisp
@@ -39,7 +39,7 @@ Distributed under the MIT license (see LICENSE file)
   (typep object 'mp:mutex))
 
 (defun recursive-lock-p (object)
-  (and (typep object 'mp:lock)
+  (and (typep object 'mp:mutex)
        (mp:recursive-lock-p object)))
 
 (defun make-lock (&optional name)


### PR DESCRIPTION
* mp:lock is no longer exported, testing for it was wrong anyhow