### PR TITLE
CCL semaphores now have a count argument

### DIFF
--- a/src/impl-clozure.lisp
+++ b/src/impl-clozure.lisp
@@ -96,9 +96,7 @@ Distributed under the MIT license (see LICENSE file)
 
 (defun make-semaphore (&key name (count 0))
   (declare (ignore name))
-  (let ((semaphore (ccl:make-semaphore)))
-    (dotimes (c count) (ccl:signal-semaphore semaphore))
-    semaphore))
+  (ccl:make-semaphore :count count))
 
 (defun signal-semaphore (semaphore &key (count 1))
   (dotimes (c count) (ccl:signal-semaphore semaphore)))


### PR DESCRIPTION
I submitted:
https://github.com/Clozure/ccl/pull/310/files
Make semaphore can now just set the count argument.