### PR TITLE
Several changes to the Genera implementation

### DIFF
--- a/src/bordeaux-threads.lisp
+++ b/src/bordeaux-threads.lisp
@@ -50,7 +50,7 @@ Distributed under the MIT license (see LICENSE file)
 (define-condition interrupt ()
   ((tag :initarg :tag :reader interrupt-tag)))
 
-#-sbcl
+#-(or sbcl genera)
 (defmacro with-timeout ((timeout) &body body)
   "Execute `BODY' and signal a condition of type TIMEOUT if the execution of
 BODY does not complete within `TIMEOUT' seconds. On implementations which do not

--- a/src/impl-genera.lisp
+++ b/src/impl-genera.lisp
@@ -9,10 +9,19 @@ Distributed under the MIT license (see LICENSE file)
 (deftype thread ()
   'process:process)
 
+(defvar *thread-recursive-lock-key* 0)
+
 ;;; Thread Creation
 
 (defun %make-thread (function name)
-  (process:process-run-function name function))
+  (flet ((top-level ()
+           (let* ((*thread-recursive-lock-key* 0)
+                  (return-values
+                    (multiple-value-list (funcall function))))
+             (setf (si:process-spare-slot-4 scl:*current-process*) return-values)
+             (values-list return-values))))
+    (declare (dynamic-extent #'top-level))
+    (process:process-run-function name #'top-level)))
 
 (defun current-thread ()
   scl:*current-process*)
@@ -32,24 +41,25 @@ Distributed under the MIT license (see LICENSE file)
 (defun make-lock (&optional name)
   (let ((lock (process:make-lock (or name "Anonymous lock"))))
     (make-lock-internal :lock lock
-			:lock-argument nil)))
+                        :lock-argument nil)))
 
 (defun acquire-lock (lock &optional (wait-p t))
   (check-type lock lock)
-  (setf (lock-lock-argument lock) (process:make-lock-argument (lock-lock lock)))
-  (if wait-p
-      (process:lock (lock-lock lock) (lock-lock-argument lock))
-      (process:with-no-other-processes
-	(when (process:lock-lockable-p (lock-lock lock))
-	  (process:lock (lock-lock lock) (lock-lock-argument lock))))))
+  (let ((lock-argument (process:make-lock-argument (lock-lock lock))))
+    (cond (wait-p
+           (process:lock (lock-lock lock) lock-argument)
+           (setf (lock-lock-argument lock) lock-argument)
+           t)
+          (t
+           (process:with-no-other-processes
+             (when (process:lock-lockable-p (lock-lock lock))
+               (process:lock (lock-lock lock) lock-argument)
+               (setf (lock-lock-argument lock) lock-argument)
+               t))))))
 
 (defun release-lock (lock)
   (check-type lock lock)
   (process:unlock (lock-lock lock) (scl:shiftf (lock-lock-argument lock) nil)))
-
-(defmacro with-lock-held ((place) &body body)
-  `(process:with-lock ((lock-lock ,place))
-     ,@body))
 
 (defstruct (recursive-lock (:constructor make-recursive-lock-internal))
   lock
@@ -57,22 +67,47 @@ Distributed under the MIT license (see LICENSE file)
 
 (defun make-recursive-lock (&optional name)
   (make-recursive-lock-internal :lock (process:make-lock (or name "Anonymous recursive lock")
-							 :recursive t)
-				:lock-arguments nil))
+                                                         :recursive t)
+                                :lock-arguments (make-hash-table :test #'equal)))
 
 (defun acquire-recursive-lock (lock)
   (check-type lock recursive-lock)
-  (process:lock (recursive-lock-lock lock)
-		(car (push (process:make-lock-argument (recursive-lock-lock lock))
-			   (recursive-lock-lock-arguments lock)))))
+  (acquire-recursive-lock-internal lock))
+
+(defun acquire-recursive-lock-internal (lock &optional timeout)
+  (let ((key (cons (incf *thread-recursive-lock-key*) scl:*current-process*))
+        (lock-argument (process:make-lock-argument (recursive-lock-lock lock))))
+    (cond (timeout
+           (process:with-no-other-processes
+             (when (process:lock-lockable-p (recursive-lock-lock lock))
+               (process:lock (recursive-lock-lock lock) lock-argument)
+               (setf (gethash key (recursive-lock-lock-arguments lock)) lock-argument)
+               t)))
+          (t
+           (process:lock (recursive-lock-lock lock) lock-argument)
+           (setf (gethash key (recursive-lock-lock-arguments lock)) lock-argument)
+           t))))
 
 (defun release-recursive-lock (lock)
   (check-type lock recursive-lock)
-  (process:unlock (recursive-lock-lock lock) (pop (recursive-lock-lock-arguments lock))))
+  (let* ((key (cons *thread-recursive-lock-key* scl:*current-process*))
+         (lock-argument (gethash key (recursive-lock-lock-arguments lock))))
+    (prog1
+        (process:unlock (recursive-lock-lock lock) lock-argument)
+      (decf *thread-recursive-lock-key*)
+      (remhash key (recursive-lock-lock-arguments lock)))))
 
-(defmacro with-recursive-lock-held ((place) &body body)
-  `(process:with-lock ((recursive-lock-lock ,place))
-     ,@body))
+(defmacro with-recursive-lock-held ((place &key timeout) &body body)
+  `(with-recursive-lock-held-internal ,place ,timeout #'(lambda () ,@body)))
+
+(defun with-recursive-lock-held-internal (lock timeout function)
+  (check-type lock recursive-lock)
+  (assert (typep timeout '(or null (satisfies zerop))) (timeout)
+          'bordeaux-mp-condition :message ":TIMEOUT value must be either NIL or 0")
+  (when (acquire-recursive-lock-internal lock timeout)
+    (unwind-protect
+        (funcall function)
+      (release-recursive-lock lock))))
 
 ;;; Resource contention: condition variables
 
@@ -85,20 +120,29 @@ Distributed under the MIT license (see LICENSE file)
 (defun make-condition-variable (&key name)
   (%make-condition-variable :name name))
 
-(defun condition-wait (condition-variable lock)
+(defun condition-wait (condition-variable lock &key timeout)
   (check-type condition-variable condition-variable)
   (check-type lock lock)
   (process:with-no-other-processes
     (let ((waiter (cons scl:*current-process* nil)))
       (process:atomic-updatef (condition-variable-waiters condition-variable)
-			      #'(lambda (waiters)
-				  (append waiters (scl:ncons waiter))))
-      (process:without-lock ((lock-lock lock))
-	  (process:process-block (format nil "Waiting~@[ on ~A~]"
-					 (condition-variable-name condition-variable))
-				 #'(lambda (waiter)
-				     (not (null (cdr waiter))))
-				 waiter)))))
+                              #'(lambda (waiters)
+                                  (append waiters (scl:ncons waiter))))
+      (let ((expired? t))
+        (unwind-protect
+            (progn
+              (release-lock lock)
+              (process:block-with-timeout timeout
+                                          (format nil "Waiting~@[ on ~A~]"
+                                                  (condition-variable-name condition-variable))
+                                          #'(lambda (waiter expired?-loc)
+                                              (when (not (null (cdr waiter)))
+                                                (setf (sys:location-contents expired?-loc) nil)
+                                                t))
+                                          waiter (sys:value-cell-location 'expired?))
+              expired?)
+          (unless expired?
+            (acquire-lock lock)))))))
 
 (defun condition-notify (condition-variable)
   (check-type condition-variable condition-variable)
@@ -110,6 +154,25 @@ Distributed under the MIT license (see LICENSE file)
 
 (defun thread-yield ()
   (scl:process-allow-schedule))
+
+;;; Timeouts
+
+(defmacro with-timeout ((timeout) &body body)
+  "Execute `BODY' and signal a condition of type TIMEOUT if the execution of
+BODY does not complete within `TIMEOUT' seconds."
+  `(with-timeout-internal ,timeout #'(lambda () ,@body)))
+
+(defun with-timeout-internal (timeout function)
+  ;; PROCESS:WITH-TIMEOUT either returns NIL on timeout or signals an error which,
+  ;; unforutnately, does not have a distinguished type (i.e., it's a SYS:FATAL-ERROR).
+  ;; So, rather than try to catch the error and signal our condition, we instead
+  ;; ensure the return value from the PROCESS:WITH-TIMEOUT is never NIL if there is
+  ;; no timeout. (Sigh)
+  (let ((result (process:with-timeout (timeout)
+                  (cons 'success (multiple-value-list (funcall function))))))
+    (if result
+        (values-list (cdr result))
+        (error 'timeout :length timeout))))
 
 ;;; Introspection/debugging
 
@@ -129,8 +192,9 @@ Distributed under the MIT license (see LICENSE file)
 
 (defun join-thread (thread)
   (process:process-wait (format nil "Join ~S" thread)
-			#'(lambda (thread)
-			    (not (process:process-active-p thread)))
-			thread))
+                        #'(lambda (thread)
+                            (not (process:process-active-p thread)))
+                        thread)
+  (values-list (si:process-spare-slot-4 thread)))
 
 (mark-supported)

--- a/test/bordeaux-threads-test.lisp
+++ b/test/bordeaux-threads-test.lisp
@@ -226,7 +226,7 @@ Distributed under the MIT license (see LICENSE file)
     (print "Note:  In the case of any failures, assume there are outstanding waiting threads")
     (values)))
 
-#+(or abcl allegro clisp clozure ecl lispworks6 mezzano sbcl scl)
+#+(or abcl allegro clisp clozure ecl genera lispworks6 mezzano sbcl scl)
 (test condition-wait-timeout
   (let ((lock (make-lock))
         (cvar (make-condition-variable))


### PR DESCRIPTION
Update the locking functions to match the specification. Replace the implementation of
recursive locks with one that actually works. (The prior implementation would fail horribly if
RELEASE-RECURSIVE-LOCK wasn't called in the exact reverse order across all threads.) And,
implement the :TIMEOUT key to WITH-RECURSIVE-LOCK-HELD but only if the value is NIL or 0.

With these changes to locking, add the TIMEOUT keyword to CONDITION-WAIT.  Genera now passes
the new tests in the test suite for CONDITION-WAIT with timeout and all the semaphore tests.

Implement the proper semantics for JOIN-THREAD by storing the thread's return value in a spare
slot of the SI:PROCESS object.