### PR TITLE
Added null-impl for apiv2 to fix loading on CLISP with no threads support

### DIFF
--- a/apiv2/api-threads.lisp
+++ b/apiv2/api-threads.lisp
@@ -22,7 +22,10 @@
   (trivial-garbage:make-weak-hash-table :weakness :key))
 
 (define-global-var* .known-threads-lock.
-    (make-lock :name "known-threads-lock"))
+  #+thread-support
+  (make-lock :name "known-threads-lock")
+  #-thread-support
+  nil)
 
 (defun thread-wrapper (&optional (native-thread (%current-thread)))
   (with-lock-held (.known-threads-lock.)

--- a/apiv2/impl-null.lisp
+++ b/apiv2/impl-null.lisp
@@ -1,0 +1,132 @@
+(in-package :bordeaux-threads-2)
+
+;;;
+;;; Threads
+;;;
+
+(defun %make-thread (function name)
+  (declare (ignore function name))
+  (signal-not-implemented 'make-thread))
+
+(defun %current-thread ()
+  (signal-not-implemented 'current-thread))
+
+(defun %thread-name (thread)
+  (declare (ignore thread))
+  (signal-not-implemented 'thread-name))
+
+(defun %join-thread (thread)
+  (declare (ignore thread))
+  (signal-not-implemented 'join-thread))
+
+(defun %thread-yield ()
+  (signal-not-implemented 'thread-yield))
+
+;;;
+;;; Introspection/debugging
+;;;
+
+;;; VTZ: mt:list-threads returns all threads that are not garbage collected.
+(defun %all-threads ()
+  (signal-not-implemented 'all-threads))
+
+(defun %interrupt-thread (thread function)
+  (declare (ignore thread function))
+  (signal-not-implemented 'interrupt-thread))
+
+(defun %destroy-thread (thread)
+  (declare (ignore thread))
+  (signal-not-implemented 'destroy-thread))
+
+(defun %thread-alive-p (thread)
+  (declare (ignore thread))
+  (signal-not-implemented 'thread-alive-p))
+
+
+;;;
+;;; Non-recursive locks
+;;;
+
+
+(defun %make-lock (name)
+  (declare (ignore name))
+  (signal-not-implemented 'make-lock))
+
+(defun %acquire-lock (lock waitp timeout)
+  (declare (ignore lock waitp timeout))
+  (signal-not-implemented 'acquire-lock))
+
+(defun %release-lock (lock)
+  (declare (ignore lock))
+  (signal-not-implemented 'release-lock))
+
+(defvar *with-lock-warned* nil)
+
+(defmacro %with-lock ((place timeout) &body body)
+  (declare (ignore place timeout))
+  (unless *with-lock-warned*
+    (setf *with-lock-warned* t)
+    (warn "No threading support, WITH-LOCK will be replaced with PROGN"))
+  `(progn ,@body))
+
+;;;
+;;; Recursive locks
+;;;
+
+
+(defun %make-recursive-lock (name)
+  (declare (ignore name))
+  (signal-not-implemented 'make-recursive-lock))
+
+(defun %acquire-recursive-lock (lock waitp timeout)
+  (declare (ignore lock waitp timeout))
+  (signal-not-implemented 'acquire-recursive-lock))
+
+(defun %release-recursive-lock (lock)
+  (declare (ignore lock))
+  (signal-not-implemented 'release-recursive-lock))
+
+(defvar *with-recursive-lock-warned* nil)
+
+(defmacro %with-recursive-lock ((place timeout) &body body)
+  (declare (ignore place timeout))
+  (unless *with-recursive-lock-warned*
+    (setf *with-recursive-lock-warned* t)
+    (warn "No threading support, WITH-RECURSIVELOCK will be replaced with PROGN"))
+  `(progn ,@body))
+
+
+;;;
+;;; Condition variables
+;;;
+
+
+(defun %make-condition-variable (name)
+  (declare (ignore name))
+  (signal-not-implemented 'make-condition-variable))
+
+(defun %condition-wait (cv lock timeout)
+  (declare (ignore cv lock timeout))
+  (signal-not-implemented 'condition-wait))
+
+(defun %condition-notify (cv)
+  (declare (ignore cv))
+  (signal-not-implemented 'conditioin-notify))
+
+(defun %condition-broadcast (cv)
+  (declare (ignore cv))
+  (signal-not-implemented 'condition-broadcast))
+
+
+;;;
+;;; Timeouts
+;;;
+
+(defvar *with-timeout-warned* nil)
+
+(defmacro with-timeout ((timeout) &body body)
+  (declare (ignore timeout))
+  (unless *with-timeout-warned*
+    (setf *with-timeout-warned* t)
+    (warn "No threading support, WITH-TIMEOUT will be replaced with PROGN"))
+  `(progn ,@body))

--- a/bordeaux-threads.asd
+++ b/bordeaux-threads.asd
@@ -59,15 +59,21 @@
                  #+(and thread-support digitool)
                  (:file "condition-variables")
                  (:file "default-implementations")))
-               (:module "api-v2"
+               (:module "api-v2-head"
                 :pathname "apiv2/"
                 :depends-on ("api-v1")
                 :serial t
                 :components
                 ((:file "pkgdcl")
                  (:file "bordeaux-threads")
-                 (:file "timeout-interrupt")
-                 (:file "impl-abcl" :if-feature :abcl)
+                 (:file "timeout-interrupt")))
+               (:module "api-v2-impls"
+                :pathname "apiv2/"
+                :depends-on ("api-v2-head")
+                :serial t
+                :components
+                #+thread-support
+                ((:file "impl-abcl" :if-feature :abcl)
                  (:file "impl-allegro" :if-feature :allegro)
                  (:file "impl-clasp" :if-feature :clasp)
                  (:file "impl-clisp" :if-feature :clisp)
@@ -81,8 +87,16 @@
                  (:file "impl-lispworks" :if-feature :lispworks)
                  (:file "impl-mcl" :if-feature :digitool)
                  (:file "impl-sbcl" :if-feature :sbcl)
-                 (:file "impl-scl" :if-feature :scl)
-                 (:file "atomics" :if-feature (:not :abcl))
+                 (:file "impl-scl" :if-feature :scl))
+                ;; Probably here we need impl-null like in APIv1?
+                #-thread-support
+                ((:file "impl-null")))
+               (:module "api-v2-footer"
+                :pathname "apiv2/"
+                :depends-on ("api-v2-impls")
+                :serial t
+                :components
+                ((:file "atomics" :if-feature (:not :abcl))
                  (:file "atomics-java" :if-feature :abcl)
                  (:file "api-locks")
                  (:file "api-threads")


### PR DESCRIPTION
Probably this will fix loading on other systems too, when there is not
threading support.

In old BT version implementation files were included condiitionally
if there is implementation name and :thread-support in features. But
when apiv2 was introduced, it dropped check for thread support.

This pull returns this check back.