### PR TITLE
Provide a proper implementation of the V2 API for Genera and fix a race condition in locking

### DIFF
--- a/apiv1/impl-abcl.lisp
+++ b/apiv1/impl-abcl.lisp
@@ -131,7 +131,7 @@ Distributed under the MIT license (see LICENSE file)
 (defun all-threads ()
   (let ((threads ()))
     (threads:mapcar-threads (lambda (thread)
-			      (push thread threads)))
+                              (push thread threads)))
     (reverse threads)))
 
 (defun interrupt-thread (thread function &rest args)

--- a/apiv2/api-condition-variables.lisp
+++ b/apiv2/api-condition-variables.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS-2 -*-
 ;;;; The above modeline is required for Genera. Do not change.
 
 (in-package :bordeaux-threads-2)

--- a/apiv2/api-locks.lisp
+++ b/apiv2/api-locks.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS-2 -*-
 ;;;; The above modeline is required for Genera. Do not change.
 
 (in-package :bordeaux-threads-2)

--- a/apiv2/api-semaphores.lisp
+++ b/apiv2/api-semaphores.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS-2 -*-
 ;;;; The above modeline is required for Genera. Do not change.
 
 (in-package :bordeaux-threads-2)

--- a/apiv2/api-threads.lisp
+++ b/apiv2/api-threads.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS-2 -*-
 ;;;; The above modeline is required for Genera. Do not change.
 
 (in-package :bordeaux-threads-2)
@@ -19,7 +19,7 @@
     (format stream "~S" (thread-name thread))))
 
 (define-global-var* .known-threads.
-  (trivial-garbage:make-weak-hash-table :weakness :key))
+  (trivial-garbage:make-weak-hash-table #-genera :weakness #-genera :key))
 
 (define-global-var* .known-threads-lock.
     (make-lock :name "known-threads-lock"))
@@ -74,6 +74,9 @@ CL:WITH-STANDARD-IO-SYNTAX. Forms are evaluated in the calling thread."
     (*print-level*               nil)
     (*print-lines*               nil)
     (*print-miser-width*         nil)
+    ;; Genera doesn't yet implement COPY-PPRINT-DISPATCH
+    ;; (Calling it signals an error)
+    #-genera
     (*print-pprint-dispatch*     (copy-pprint-dispatch nil))
     (*print-pretty*              nil)
     (*print-radix*               nil)
@@ -101,7 +104,7 @@ FUNCTION."
          (values (mapcar (lambda (f) (eval (cdr f))) bindings)))
     (named-lambda %establish-dynamic-env-wrapper ()
       (progv specials values
-        (with-slots (%init-lock %return-values %exit-condition) thread
+        (with-slots (%init-lock %return-values %exit-condition #+genera native-thread) thread
           (flet ((record-condition (c)
                    (setf %exit-condition c))
                  (run-function ()
@@ -109,17 +112,22 @@ FUNCTION."
                      (setf *current-thread*
                            (thread-wrapper (%current-thread)))
                      (setf %return-values (multiple-value-list
-                                           (funcall function))))))
-            (if trap-conditions
-                (handler-case
-                    (progn
-                      (run-function)
-                      (values-list %return-values))
-                  (condition (c)
-                    (record-condition c)))
-                (handler-bind
-                    ((condition #'record-condition))
-                  (run-function)))))))))
+                                            (funcall function))))))
+            (unwind-protect
+                (if trap-conditions
+                    (handler-case
+                        (progn
+                          (run-function)
+                          (values-list %return-values))
+                      (condition (c)
+                        (record-condition c)))
+                    (handler-bind
+                        ((condition #'record-condition))
+                      (run-function)))
+              ;; Genera doesn't support weak key hash tables. If we don't remove
+              ;; the native-thread object's entry from the hash table here, we'll
+              ;; never be able to GC the native-thread after it terminates
+              #+genera  (remhash native-thread .known-threads.))))))))
 
 
 ;;;

--- a/apiv2/bordeaux-threads.lisp
+++ b/apiv2/bordeaux-threads.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS-2 -*-
 ;;;; The above modeline is required for Genera. Do not change.
 
 (in-package :bordeaux-threads-2)

--- a/apiv2/impl-abcl.lisp
+++ b/apiv2/impl-abcl.lisp
@@ -31,7 +31,7 @@
 (defun %all-threads ()
   (let ((threads ()))
     (threads:mapcar-threads (lambda (thread)
-			      (push thread threads)))
+                              (push thread threads)))
     (nreverse threads)))
 
 (defun %interrupt-thread (thread function)

--- a/apiv2/impl-condition-variables-semaphores.lisp
+++ b/apiv2/impl-condition-variables-semaphores.lisp
@@ -9,8 +9,30 @@
 ;;; without trying too hard to be very fast.
 ;;;
 
+(defstruct queue
+  (vector (make-array 7 :adjustable t :fill-pointer 0) :type vector)
+  (lock (%make-lock nil) :type native-lock))
+
+(defun queue-drain (queue)
+  (%with-lock ((queue-lock queue) nil)
+    (shiftf (queue-vector queue)
+            (make-array 7 :adjustable t :fill-pointer 0))))
+
+(defun queue-dequeue (queue)
+  (%with-lock ((queue-lock queue) nil)
+    (let ((vector (queue-vector queue)))
+      (if (zerop (length vector))
+          nil
+          (vector-pop vector)))))
+
+(defun queue-enqueue (queue value)
+  (%with-lock ((queue-lock queue) nil)
+    (vector-push-extend value (queue-vector queue))))
+
 (defstruct (condition-variable
-            (:constructor %make-condition-variable (name)))
+            (:constructor %make-condition-variable (name))
+            ;; CONDITION-VARIABLE-P is defined in API-CONDITION-VARIABLES.LISP
+            (:predicate nil))
   name
   (queue (make-queue)))
 

--- a/apiv2/impl-genera.lisp
+++ b/apiv2/impl-genera.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: BORDEAUX-THREADS; Base: 10; -*-
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: BORDEAUX-THREADS-2; Base: 10; -*-
 
 (in-package :bordeaux-threads-2)
 
@@ -13,12 +13,8 @@
 
 (defun %make-thread (function name)
   (flet ((top-level ()
-           (let* ((*thread-recursive-lock-key* 0)
-                  (return-values
-                    (multiple-value-list (funcall function))))
-             (setf (si:process-spare-slot-4 scl:*current-process*)
-                   return-values)
-             (values-list return-values))))
+           (let ((*thread-recursive-lock-key* 0))
+             (funcall function))))
     (declare (dynamic-extent #'top-level))
     (process:process-run-function name #'top-level)))
 
@@ -32,11 +28,13 @@
   (process:process-wait (format nil "Join ~S" thread)
                         #'(lambda (thread)
                             (not (process:process-active-p thread)))
-                        thread)
-  (values-list (si:process-spare-slot-4 thread)))
+                        thread))
 
 (defun %thread-yield ()
   (scl:process-allow-schedule))
+
+(defun %start-multiprocessing () 
+  (values))
 
 ;;;
 ;;; Introspection/debugging
@@ -49,7 +47,7 @@
   (process:process-interrupt thread function))
 
 (defun %destroy-thread (thread)
-  (process:process-kill thread :without-aborts :force))
+  (process:process-kill thread :force))
 
 (defun %thread-alive-p (thread)
   (process:process-active-p thread))
@@ -59,7 +57,7 @@
 ;;; Non-recursive locks
 ;;;
 
-(defstruct (%lock (:constructor make-lock-internal))
+(defstruct (%lock (:constructor make-%lock-internal))
   lock
   lock-argument)
 
@@ -67,19 +65,23 @@
 
 (defun %make-lock (name)
   (let ((lock (process:make-lock name)))
-    (make-lock-internal :lock lock
-                        :lock-argument nil)))
+    (make-%lock-internal :lock lock
+                         :lock-argument nil)))
 
-(mark-not-implemented 'acquire-lock :timeout)
 (defun %acquire-lock (lock waitp timeout)
-  (check-type lock lock)
-  (when timeout
-    (signal-not-implemented 'acquire-lock :timeout))
+  (check-type lock %lock)
   (let ((lock-argument (process:make-lock-argument (%lock-lock lock))))
     (cond (waitp
-           (process:lock (%lock-lock lock) lock-argument)
-           (setf (%lock-lock-argument lock) lock-argument)
-           t)
+           (if timeout
+               (process:with-timeout (timeout)
+                 (process:with-no-other-processes 
+                   (process:lock (%lock-lock lock) lock-argument)
+                   (setf (%lock-lock-argument lock) lock-argument)
+                   t))
+               (process:with-no-other-processes 
+                 (process:lock (%lock-lock lock) lock-argument)
+                 (setf (%lock-lock-argument lock) lock-argument)
+                 t)))
           (t
            (process:with-no-other-processes
                (when (process:lock-lockable-p (%lock-lock lock))
@@ -88,62 +90,56 @@
                  t))))))
 
 (defun %release-lock (lock)
-  (check-type lock lock)
-  (process:unlock (%lock-lock lock) (scl:shiftf (%lock-lock-argument lock) nil)))
+  (check-type lock %lock)
+  (process:with-no-other-processes
+    (process:unlock (%lock-lock lock) (scl:shiftf (%lock-lock-argument lock) nil))))
 
 ;;;
 ;;; Recursive locks
 ;;;
 
-(defstruct (%recursive-lock (:constructor make-recursive-lock-internal))
+(defstruct (%recursive-lock (:constructor make-%recursive-lock-internal))
   lock
   lock-arguments)
 
 (deftype native-recursive-lock () '%recursive-lock)
 
 (defun %make-recursive-lock (name)
-  (make-recursive-lock-internal
+  (make-%recursive-lock-internal
    :lock (process:make-lock name :recursive t)
    :lock-arguments (make-hash-table :test #'equal)))
 
 (defun %acquire-recursive-lock (lock waitp timeout)
-  (check-type lock recursive-lock)
-  (acquire-recursive-lock-internal lock (if (null waitp) 0 timeout)))
-
-(defun acquire-recursive-lock-internal (lock timeout)
+  (check-type lock %recursive-lock)
   (let ((key (cons (incf *thread-recursive-lock-key*) scl:*current-process*))
-        (lock-argument (process:make-lock-argument (recursive-lock-lock lock))))
-    (cond (timeout
-           (process:with-no-other-processes
-             (when (process:lock-lockable-p (recursive-lock-lock lock))
-               (process:lock (recursive-lock-lock lock) lock-argument)
-               (setf (gethash key (recursive-lock-lock-arguments lock)) lock-argument)
-               t)))
+        (lock-argument (process:make-lock-argument (%recursive-lock-lock lock))))
+    (cond (waitp
+           (if timeout
+               (process:with-timeout (timeout)
+                 (process:with-no-other-processes
+                   (process:lock (%recursive-lock-lock lock) lock-argument)
+                   (setf (gethash key (%recursive-lock-lock-arguments lock)) lock-argument)
+                   t))
+               (process:with-no-other-processes
+                 (process:lock (%recursive-lock-lock lock) lock-argument)
+                 (setf (gethash key (%recursive-lock-lock-arguments lock)) lock-argument)
+                 t)))
           (t
-           (process:lock (recursive-lock-lock lock) lock-argument)
-           (setf (gethash key (recursive-lock-lock-arguments lock)) lock-argument)
-           t))))
+           (process:with-no-other-processes
+             (when (process:lock-lockable-p (%recursive-lock-lock lock))
+               (process:lock (%recursive-lock-lock lock) lock-argument)
+               (setf (gethash key (%recursive-lock-lock-arguments lock)) lock-argument)
+               t))))))
 
 (defun %release-recursive-lock (lock)
-  (check-type lock recursive-lock)
+  (check-type lock %recursive-lock)
   (let* ((key (cons *thread-recursive-lock-key* scl:*current-process*))
-         (lock-argument (gethash key (recursive-lock-lock-arguments lock))))
-    (prog1
-        (process:unlock (recursive-lock-lock lock) lock-argument)
-      (decf *thread-recursive-lock-key*)
-      (remhash key (recursive-lock-lock-arguments lock)))))
-
-(defmacro %with-recursive-lock ((place timeout) &body body)
-  `(with-recursive-lock-held-internal ,place ,timeout #'(lambda () ,@body)))
-
-(defun with-recursive-lock-held-internal (lock timeout function)
-  (check-type lock recursive-lock)
-  (assert (typep timeout '(or null (satisfies zerop))) (timeout)
-          'bordeaux-threads-error :message ":TIMEOUT value must be either NIL or 0")
-  (when (acquire-recursive-lock-internal lock timeout)
-    (unwind-protect
-        (funcall function)
-      (release-recursive-lock lock))))
+         (lock-argument (gethash key (%recursive-lock-lock-arguments lock))))
+    (process:with-no-other-processes
+      (prog1
+          (process:unlock (%recursive-lock-lock lock) lock-argument)
+        (decf *thread-recursive-lock-key*)
+        (remhash key (%recursive-lock-lock-arguments lock))))))
 
 
 ;;;
@@ -152,7 +148,9 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defstruct (condition-variable
-              (:constructor %make-condition-variable (name)))
+              (:constructor %make-condition-variable (name))
+              ;; CONDITION-VARIABLE-P is defined in API-CONDITION-VARIABLES.LISP
+              (:predicate nil))
     "Bordeaux-threads implementation of condition variables."
     name
     (waiters nil)))
@@ -163,7 +161,7 @@
 
 (defun %condition-wait (cv lock timeout)
   (check-type cv condition-variable)
-  (check-type lock lock)
+  (check-type lock %lock)
   (process:with-no-other-processes
     (let ((waiter (cons scl:*current-process* nil)))
       (process:atomic-updatef (condition-variable-waiters cv)
@@ -172,32 +170,33 @@
       (let ((expired? t))
         (unwind-protect
             (progn
-              (release-lock lock)
-              (process:block-with-timeout
-               timeout
-               (format nil "Waiting~@[ on ~A~]"
-                       (condition-variable-name cv))
-               #'(lambda (waiter expired?-loc)
-                   (when (not (null (cdr waiter)))
-                     (setf (sys:location-contents expired?-loc) nil)
-                     t))
-               waiter (sys:value-cell-location 'expired?))
+              (%release-lock lock)
+              (process:block-with-timeout timeout
+                                          (format nil "Waiting~@[ on ~A~]"
+                                                  (condition-variable-name cv))
+                                          #'(lambda (waiter expired?-loc)
+                                              (when (not (null (cdr waiter)))
+                                                (setf (sys:location-contents expired?-loc) nil)
+                                                t))
+                                          waiter (sys:value-cell-location 'expired?))
               expired?)
           (unless expired?
             (%acquire-lock lock t nil)))))))
 
 (defun %condition-notify (cv)
   (check-type cv condition-variable)
-  (let ((waiter (process:atomic-pop
-                 (condition-variable-waiters cv))))
+  (let ((waiter (process:atomic-pop (condition-variable-waiters cv))))
     (when waiter
       (setf (cdr waiter) t)
       (process:wakeup (car waiter)))))
 
-(mark-not-implemented 'condition-broadcast)
 (defun %condition-broadcast (cv)
-  (declare (ignore cv))
-  (signal-not-implemented 'condition-broadcast))
+  (check-type cv condition-variable)
+  (loop for waiter in (process:atomic-replacef (condition-variable-waiters cv) nil)
+        do
+    (setf (cdr waiter) t)
+    (process:wakeup (car waiter))))
+
 
 
 ;;;

--- a/apiv2/timeout-interrupt.lisp
+++ b/apiv2/timeout-interrupt.lisp
@@ -1,4 +1,4 @@
-;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS-2 -*-
 ;;;; The above modeline is required for Genera. Do not change.
 
 (in-package :bordeaux-threads-2)

--- a/test/not-implemented.lisp
+++ b/test/not-implemented.lisp
@@ -1,4 +1,5 @@
-;;;; -*- indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS-2/TEST -*-
+;;;; The above modeline is required for Genera. Do not change.
 
 (in-package :bordeaux-threads-2/test)
 

--- a/test/pkgdcl.lisp
+++ b/test/pkgdcl.lisp
@@ -1,4 +1,5 @@
-;;;; -*- indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: CL-USER -*-
+;;;; The above modeline is required for Genera. Do not change.
 
 (defpackage :bordeaux-threads-2/test
   (:use :common-lisp :alexandria :bordeaux-threads-2 :fiveam)

--- a/test/tests-v1.lisp
+++ b/test/tests-v1.lisp
@@ -1,3 +1,6 @@
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: CL-USER -*-
+;;;; The above modeline is required for Genera. Do not change.
+
 #|
 Copyright 2006,2007 Greg Pfeil
 

--- a/test/tests-v2.lisp
+++ b/test/tests-v2.lisp
@@ -1,4 +1,5 @@
-;;;; -*- indent-tabs-mode: nil -*-
+;;;; -*- Mode: LISP; Syntax: ANSI-Common-lisp; Base: 10; Package: BORDEAUX-THREADS-2/TEST -*-
+;;;; The above modeline is required for Genera. Do not change.
 
 (in-package :bordeaux-threads-2/test)
 
@@ -316,8 +317,8 @@
              (with-lock-held (*lock*)
                (loop
                  until (= i *shared*)
-                 do (sleep (random .1))
-                    (condition-wait cv *lock*))
+                 do (condition-wait cv *lock*)
+                    (sleep (random .1)))
                (incf *shared*))
              (condition-broadcast cv)))
       (let ((num-procs 30))


### PR DESCRIPTION
Move QUEUE from atomics.lisp to impl-condition-variables-semaphores.lisp, which is
the only file which uses QUEUE, as the Genera implementation does not define %WITH-LOCK.
(impl-condition-variables-semaphores.lisp is only used by CCL.)

On Genera, fix the calls to PROCESS:PROCESS-KILL in DESTROY-THREAD --
the WITHOUT-ABORTS argument is an optional not a keyword argument.

Fix a race condition in locking and unlocking --
Assume two processes, A and B, and a lock. Process A locks the lock. Process B then tries
to lock the lock and blocks until A unlocks it. As currently written, when process A
unlocks the lock, Genera might switch to process B before process A can reset the lock's
internal BT state to indicate it no longer has the lock. Process B then updates the
internal state to indicate it has the lock which Genera has given it. Process A then
runs and reset the lock's internal state. When process B tries to unlock the lock,
it will crash because it passes an invalid value to Genera's process:unlock.

The fix is to make all lock/unlock operations in BT atomic w.r.t. locking/unlocking
the Genera lock and updating the internal state.