### PR TITLE
Don't unconditionally return t on condition-variable-wait for Lispworks

### DIFF
--- a/apiv1/impl-lispworks.lisp
+++ b/apiv1/impl-lispworks.lisp
@@ -100,8 +100,7 @@ Distributed under the MIT license (see LICENSE file)
 
 #-(or lispworks4 lispworks5)
 (defun condition-wait (condition-variable lock &key timeout)
-  (mp:condition-variable-wait condition-variable lock :timeout timeout)
-  t)
+  (mp:condition-variable-wait condition-variable lock :timeout timeout))
 
 #-(or lispworks4 lispworks5)
 (defun condition-notify (condition-variable)


### PR DESCRIPTION
It looks like this is correctly implemented in APIv2, but in APIv1, we're always returning t. The official Lispworks documentation says we can rely on the return the value returned by mp:condition-variable-wait: http://www.lispworks.com/documentation/lw80/lw/lw-mp-18.htm