### PR TITLE
Fix semaphore count issue on CCL < 1.12 (pertaining #20)

### DIFF
--- a/apiv2/impl-clozure.lisp
+++ b/apiv2/impl-clozure.lisp
@@ -107,9 +107,16 @@
 
 (deftype semaphore () 'ccl:semaphore)
 
+;;; CCL:MAKE-SEMAPHORE had been extended to accept COUNT argument
+#+(ccl-1.12)
 (defun %make-semaphore (name count)
   (declare (ignore name))
   (ccl:make-semaphore :count count))
+
+#-(ccl-1.12)
+(defun %make-semaphore (name count)
+  (declare (ignore name count))
+  (ccl:make-semaphore))
 
 (defun %signal-semaphore (semaphore count)
   (dotimes (c count) (ccl:signal-semaphore semaphore)))

--- a/apiv2/impl-clozure.lisp
+++ b/apiv2/impl-clozure.lisp
@@ -108,12 +108,12 @@
 (deftype semaphore () 'ccl:semaphore)
 
 ;;; CCL:MAKE-SEMAPHORE had been extended to accept COUNT argument
-#+(ccl-1.12)
+#+ccl-1.12
 (defun %make-semaphore (name count)
   (declare (ignore name))
   (ccl:make-semaphore :count count))
 
-#-(ccl-1.12)
+#-ccl-1.12
 (defun %make-semaphore (name count)
   (declare (ignore name count))
   (ccl:make-semaphore))


### PR DESCRIPTION
Versions 1.11 and below do not accept the COUNT argument. Patching to ignore it.