### PR TITLE
Suppress the undefined function compiler warning for bt2::%start-multiprocessing

### DIFF
--- a/apiv2/impl-genera.lisp
+++ b/apiv2/impl-genera.lisp
@@ -6,6 +6,9 @@
 ;;; Threads
 ;;;
 
+;; Suppresses the undefined function compiler warning
+(defun %start-multiprocessing ())
+
 (deftype native-thread ()
   'process:process)
 


### PR DESCRIPTION
Compiling the Bordeaux-Threads library on Genera produces the warning
```
The following functions were referenced but don't seem defined:
 BT2::%START-MULTIPROCESSING referenced by BT2:START-MULTIPROCESSING
```
This PR adds a definition of the function to suppress the warning. (I tried using an FTYPE declaration but the Genera compiler ignores it.)
